### PR TITLE
修改了scss处理的loader，以及采用更小粒度的hash打包项目

### DIFF
--- a/config/webpack.prod.conf.js
+++ b/config/webpack.prod.conf.js
@@ -14,7 +14,7 @@ const webpackConfigProd = {
 	output: {
 		path: path.resolve(__dirname, '../dist'),
 		// 打包多出口文件
-		filename: 'js/[name].[hash].js',
+		filename: 'js/[name].[chunkhash].js',
 		publicPath: '../'
 	},
 	
@@ -60,7 +60,7 @@ const webpackConfigProd = {
 		}),
 		// 分离css插件参数为提取出去的路径
 		new extractTextPlugin({
-			filename: 'css/[name].[hash:8].min.css',
+			filename: 'css/[name].[md5:contenthash:hex:8].min.css',
 		}),
 	]
 

--- a/config/webpack.rules.conf.js
+++ b/config/webpack.rules.conf.js
@@ -2,9 +2,9 @@ const extractTextPlugin = require("extract-text-webpack-plugin");
 const rules = [{
         test: /\.(css|scss|sass)$/,
         // 区别开发环境和生成环境
-        use: process.env.NODE_ENV === "development" ? ["style-loader", "css-loader", "sass-loader", "postcss-loader"] : extractTextPlugin.extract({
+    use: process.env.NODE_ENV === "development" ? ["style-loader", "css-loader", "postcss-loader", "sass-loader"] : extractTextPlugin.extract({
             fallback: "style-loader",
-            use: ["css-loader", "sass-loader", "postcss-loader"],
+        use: ["css-loader", "postcss-loader", "sass-loader"],
             // css中的基础路径
             publicPath: "../"
         })


### PR DESCRIPTION
你好，此次PR涉及两个修改，对应两个提交：
1. 调整了loader的顺序，将`postcss-loader`放于`sass-loader`之前，理由有二：
- 这个是官方推荐的做法：
> Use it after css-loader and style-loader, but before other preprocessor loaders like e.g sass|less|stylus-loader, if you use any.
- 这样可以避免在样式中使用`//`注释的报错

2. 采用了更细粒度的hash进行打包，原因是生产环境下往往希望充分利用缓存